### PR TITLE
removed the unused code

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "chalk": "^3.0.0",
     "clear": "^0.1.0",
     "clui": "^0.3.6",
-    "extract-zip": "^2.0.0",
     "figlet": "^1.2.4",
     "inquirer": "^7.0.4",
     "minimist": "^1.2.0",

--- a/wm_codegen_utils.js
+++ b/wm_codegen_utils.js
@@ -25,9 +25,6 @@ const getProjVersion = path => {
   return pVersion;
 };
 
-const getCodegenS3Path = (version='') =>
-  version!==''?`https://s3.amazonaws.com/maven.wavemaker.com/release/com/wavemaker/app/build/wavemaker-ng-codegen/${version}/wavemaker-ng-codegen-${version}-wmapp.zip`:'';
-
 const execNpmInstall = async path => {
     await exec(`cd ${getCodegenPath(path)} && npm i`);
 }
@@ -37,7 +34,7 @@ const getCodegenPackageName = ()=>{
 }
 
 const installCodegen = async (path) => {
-  await exec('npm install '+  getCodegenPackageName() +'@'+ getProjVersion(path));
+  await exec('npm install --no-save '+  getCodegenPackageName() +'@'+ getProjVersion(path));
 }
 const execCodegenCli = async (codegenPath, projectPath) => {
   let angularCodegenPath = getCodegenPath(codegenPath);


### PR DESCRIPTION
Removed the unused code
As we are installing wavemaker angular-codegen repo dynamically and not from package.json file, have to use the flag --no-save otherwise it is adding this repo to the package.json file every time build happens which is not required 